### PR TITLE
Now it is possible to configure pac4j in the YAML

### DIFF
--- a/src/main/java/org/pac4j/dropwizard/DefaultFeatureSupport.java
+++ b/src/main/java/org/pac4j/dropwizard/DefaultFeatureSupport.java
@@ -1,0 +1,90 @@
+package org.pac4j.dropwizard;
+
+import org.pac4j.core.authorization.authorizer.Authorizer;
+import org.pac4j.core.authorization.generator.AuthorizationGenerator;
+import org.pac4j.core.client.BaseClient;
+import org.pac4j.core.client.Client;
+import org.pac4j.core.credentials.authenticator.Authenticator;
+import org.pac4j.core.credentials.extractor.CredentialsExtractor;
+import org.pac4j.core.credentials.password.PasswordEncoder;
+import org.pac4j.core.http.CallbackUrlResolver;
+import org.pac4j.core.matching.Matcher;
+import org.pac4j.core.profile.creator.ProfileCreator;
+import org.pac4j.core.redirect.RedirectActionBuilder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.dropwizard.setup.Bootstrap;
+
+/**
+ * This can be specialized in order to redefine some of the mixins to customize
+ * Jackson's behaviour to parse pac4j's {@link Pac4jFactory} in case things are
+ * missing.
+ * 
+ * @author Victor Noel - Linagora
+ * @since 1.0.0
+ *
+ */
+public class DefaultFeatureSupport implements Pac4jFeatureSupport {
+
+    @Override
+    public void setup(Bootstrap<?> bootstrap) {
+        ObjectMapper om = bootstrap.getObjectMapper();
+        om.addMixIn(Client.class, clientMixin());
+        om.addMixIn(BaseClient.class, baseClientMixin());
+        om.addMixIn(Authenticator.class, authenticatorMixin());
+        om.addMixIn(PasswordEncoder.class, passwordEncoderMixin());
+        om.addMixIn(CredentialsExtractor.class, credentialExtractorMixin());
+        om.addMixIn(ProfileCreator.class, profileCreatorMixin());
+        om.addMixIn(AuthorizationGenerator.class,
+                authorizationGeneratorMixin());
+        om.addMixIn(Authorizer.class, authorizerMixin());
+        om.addMixIn(Matcher.class, matcherMixin());
+        om.addMixIn(RedirectActionBuilder.class, redirectActionBuilderMixin());
+        om.addMixIn(CallbackUrlResolver.class, callbackUrlResolverMixin());
+    }
+
+    private Class<?> callbackUrlResolverMixin() {
+        return Pac4jMixins.InstantiateByClassNameMixin.class;
+    }
+
+    private Class<?> redirectActionBuilderMixin() {
+        return Pac4jMixins.InstantiateByClassNameMixin.class;
+    }
+
+    private Class<?> matcherMixin() {
+        return Pac4jMixins.InstantiateByClassNameMixin.class;
+    }
+
+    private Class<?> authorizerMixin() {
+        return Pac4jMixins.InstantiateByClassNameMixin.class;
+    }
+
+    private Class<?> authorizationGeneratorMixin() {
+        return Pac4jMixins.InstantiateByClassNameMixin.class;
+    }
+
+    private Class<?> profileCreatorMixin() {
+        return Pac4jMixins.InstantiateByClassNameMixin.class;
+    }
+
+    private Class<?> credentialExtractorMixin() {
+        return Pac4jMixins.InstantiateByClassNameMixin.class;
+    }
+
+    private Class<?> passwordEncoderMixin() {
+        return Pac4jMixins.InstantiateByClassNameMixin.class;
+    }
+
+    private Class<?> authenticatorMixin() {
+        return Pac4jMixins.InstantiateByClassNameMixin.class;
+    }
+
+    private Class<?> baseClientMixin() {
+        return Pac4jMixins.BaseClientMixin.class;
+    }
+
+    private Class<?> clientMixin() {
+        return Pac4jMixins.ClientMixin.class;
+    }
+}

--- a/src/main/java/org/pac4j/dropwizard/Pac4jConfiguration.java
+++ b/src/main/java/org/pac4j/dropwizard/Pac4jConfiguration.java
@@ -1,7 +1,17 @@
 package org.pac4j.dropwizard;
 
+import io.dropwizard.Bundle;
 import io.dropwizard.Configuration;
 
+/**
+ * 
+ * {@link Bundle}s can extend this to get a {@link Pac4jFactory}.
+ * 
+ * @author Evan Meagher
+ * @since 1.0.0
+ *
+ * @param <T>
+ */
 public interface Pac4jConfiguration<T extends Configuration> {
     Pac4jFactory getPac4jFactory(T configuration);
 }

--- a/src/main/java/org/pac4j/dropwizard/Pac4jFactory.java
+++ b/src/main/java/org/pac4j/dropwizard/Pac4jFactory.java
@@ -1,35 +1,165 @@
 package org.pac4j.dropwizard;
 
-import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
+import javax.validation.constraints.NotNull;
+
+import org.pac4j.core.authorization.authorizer.Authorizer;
+import org.pac4j.core.authorization.generator.AuthorizationGenerator;
+import org.pac4j.core.client.Client;
+import org.pac4j.core.client.Clients;
+import org.pac4j.core.config.Config;
+import org.pac4j.core.http.CallbackUrlResolver;
+import org.pac4j.core.matching.Matcher;
 import org.pac4j.jax.rs.filters.SecurityFilter;
+import org.pac4j.jax.rs.pac4j.JaxRsCallbackUrlResolver;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 /**
- * An interface defining getters for parameters required to configure a
- * {@link SecurityFilter}.
+ * An interface defining getters for parameters required to configure a pac4j
+ * {@link Config} and {@link SecurityFilter}.
+ * 
+ * @author Evan Meagher
+ * @author Victor Noel - Linagora
+ * @since 1.0.0
  */
 public class Pac4jFactory {
 
-    private Collection<FilterConfiguration> filters;
+    @NotNull
+    private ImmutableList<FilterConfiguration> filters = ImmutableList.of();
+
+    private String clientNameParameter;
+
+    private String callbackUrl;
+
+    private CallbackUrlResolver callbackUrlResolver = new JaxRsCallbackUrlResolver();
+
+    @NotNull
+    private ImmutableList<AuthorizationGenerator> authorizationGenerators = ImmutableList
+            .of();
+
+    @NotNull
+    private ImmutableMap<String, Matcher> matchers = ImmutableMap.of();
+
+    @NotNull
+    private ImmutableList<Client> clients = ImmutableList.of();
+
+    @NotNull
+    private ImmutableMap<String, Authorizer> authorizers = ImmutableMap.of();
 
     @JsonProperty
-    public Collection<FilterConfiguration> getFilters() {
+    public ImmutableList<FilterConfiguration> getFilters() {
         return filters;
     }
 
     @JsonProperty
-    public void setFilters(Collection<FilterConfiguration> filters) {
-        this.filters = filters;
+    public void setFilters(List<FilterConfiguration> filters) {
+        this.filters = ImmutableList.copyOf(filters);
+    }
+
+    @JsonProperty
+    public String getClientNameParameter() {
+        return clientNameParameter;
+    }
+
+    @JsonProperty
+    public void setClientNameParameter(String clientNameParameter) {
+        this.clientNameParameter = clientNameParameter;
+    }
+
+    @JsonProperty
+    public String getCallbackUrl() {
+        return callbackUrl;
+    }
+
+    @JsonProperty
+    public void setCallbackUrl(String callbackUrl) {
+        this.callbackUrl = callbackUrl;
+    }
+
+    @JsonProperty
+    public ImmutableList<AuthorizationGenerator> getAuthorizationGenerators() {
+        return authorizationGenerators;
+    }
+    
+    @JsonProperty
+    public void setAuthorizationGenerators(
+            List<AuthorizationGenerator> authorizationGenerators) {
+        this.authorizationGenerators = ImmutableList
+                .copyOf(authorizationGenerators);
+    }
+
+    @JsonProperty
+    public ImmutableMap<String, Matcher> getMatchers() {
+        return matchers;
+    }
+    
+    @JsonProperty
+    public void setMatchers(Map<String, Matcher> matchers) {
+        this.matchers = ImmutableMap.copyOf(matchers);
+    }
+
+    @JsonProperty
+    public ImmutableList<Client> getClients() {
+        return clients;
+    }
+    
+    @JsonProperty
+    public void setClients(List<Client> clients) {
+        this.clients = ImmutableList.copyOf(clients);
+    }
+
+    @JsonProperty
+    public ImmutableMap<String, Authorizer> getAuthorizers() {
+        return authorizers;
+    }
+
+    @JsonProperty
+    public void setAuthorizers(Map<String, Authorizer> authorizers) {
+        this.authorizers = ImmutableMap.copyOf(authorizers);
+    }
+
+    @JsonProperty
+    public CallbackUrlResolver getCallbackUrlResolver() {
+        return callbackUrlResolver;
+    }
+
+    @JsonProperty
+    public void setCallbackUrlResolver(
+            CallbackUrlResolver callbackUrlResolver) {
+        this.callbackUrlResolver = callbackUrlResolver;
+    }
+
+    public Config build() {
+        Clients client = new Clients();
+        Config config = new Config(client);
+
+        client.setCallbackUrl(callbackUrl);
+        client.setCallbackUrlResolver(callbackUrlResolver);
+        client.setClientNameParameter(clientNameParameter);
+        client.setAuthorizationGenerators(authorizationGenerators);
+        client.setClients(clients);
+
+        config.setAuthorizers(authorizers);
+        config.setMatchers(matchers);
+
+        return config;
     }
 
     public static class FilterConfiguration {
 
         private Boolean skipResponse;
+
         private String clients;
+
         private String authorizers;
+
         private String matchers;
+
         private Boolean multiProfile;
 
         /**

--- a/src/main/java/org/pac4j/dropwizard/Pac4jFeatureSupport.java
+++ b/src/main/java/org/pac4j/dropwizard/Pac4jFeatureSupport.java
@@ -1,0 +1,15 @@
+package org.pac4j.dropwizard;
+
+import io.dropwizard.setup.Bootstrap;
+
+/**
+ * An interface to add optional Jackson's behaviour customizations to
+ * {@link Pac4jBundle}.
+ * 
+ * @author Victor Noel - Linagora
+ * @since 1.0.0
+ *
+ */
+public interface Pac4jFeatureSupport {
+    void setup(Bootstrap<?> bootstrap);
+}

--- a/src/main/java/org/pac4j/dropwizard/Pac4jMixins.java
+++ b/src/main/java/org/pac4j/dropwizard/Pac4jMixins.java
@@ -1,0 +1,45 @@
+package org.pac4j.dropwizard;
+
+import java.util.List;
+
+import org.pac4j.core.authorization.generator.AuthorizationGenerator;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Some mixins usable to tweak Jackson behaviour when parsing dropwizard's YAML
+ * configuration file.
+ * 
+ * @author Victor Noel - Linagora
+ * @since 1.0.0
+ */
+public class Pac4jMixins {
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.WRAPPER_OBJECT)
+    public abstract static class ClientMixin {
+
+    }
+
+    public abstract static class BaseClientMixin extends ClientMixin {
+
+        @JsonProperty
+        public abstract void setAuthorizationGenerators(
+                List<AuthorizationGenerator> authorizationGenerators);
+
+        @JsonIgnore
+        public abstract void setAuthorizationGenerators(
+                AuthorizationGenerator... authorizationGenerators);
+
+        @JsonIgnore
+        public abstract void setAuthorizationGenerator(
+                AuthorizationGenerator authorizationGenerator);
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "class")
+    public abstract static class InstantiateByClassNameMixin {
+
+    }
+
+}

--- a/src/test/java/org/pac4j/dropwizard/AbstractConfigurationTest.java
+++ b/src/test/java/org/pac4j/dropwizard/AbstractConfigurationTest.java
@@ -1,0 +1,45 @@
+package org.pac4j.dropwizard;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.Resources;
+
+import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jersey.validation.Validators;
+import io.dropwizard.setup.Bootstrap;
+
+public abstract class AbstractConfigurationTest {
+
+    protected Pac4jFactory getPac4jFactory(
+            Collection<Pac4jFeatureSupport> featuresSupported,
+            String resourceName) throws Exception {
+        ObjectMapper om = Jackson.newObjectMapper();
+        Bootstrap<?> b = mock(Bootstrap.class);
+        when(b.getObjectMapper()).thenReturn(om);
+
+        for (Pac4jFeatureSupport fs : featuresSupported) {
+            fs.setup(b);
+        }
+
+        return new YamlConfigurationFactory<>(Pac4jFactory.class,
+                Validators.newValidator(), om, "dw").build(
+                        new File(Resources.getResource(resourceName).toURI()));
+    }
+    
+    protected Collection<Pac4jFeatureSupport> featuresSupported() {
+        ArrayList<Pac4jFeatureSupport> res = new ArrayList<>();
+        res.add(new DefaultFeatureSupport());
+        return res;
+    }
+    
+    protected Pac4jFactory getPac4jFactory(String resourceName) throws Exception {
+        return getPac4jFactory(featuresSupported(), resourceName);
+    }
+}

--- a/src/test/java/org/pac4j/dropwizard/DefaultConfigurationTest.java
+++ b/src/test/java/org/pac4j/dropwizard/DefaultConfigurationTest.java
@@ -1,0 +1,50 @@
+package org.pac4j.dropwizard;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.pac4j.core.client.Client;
+import org.pac4j.core.config.Config;
+import org.pac4j.core.matching.ExcludedPathMatcher;
+import org.pac4j.core.matching.Matcher;
+import org.pac4j.http.client.direct.DirectBasicAuthClient;
+import org.pac4j.http.credentials.authenticator.test.SimpleTestUsernamePasswordAuthenticator;
+
+public class DefaultConfigurationTest extends AbstractConfigurationTest {
+
+    @Test
+    public void matchers() throws Exception {
+        Pac4jFactory conf = getPac4jFactory("matchers.yaml");
+        Config config = conf.build();
+
+        assertThat(config).isNotNull();
+        assertThat(config.getMatchers()).hasSize(1)
+                .containsKey("excludeUserSession");
+        Matcher m = config.getMatchers().values().iterator().next();
+        assertThat(m).isInstanceOf(ExcludedPathMatcher.class);
+        assertThat(((ExcludedPathMatcher) m).getExcludePath())
+                .isEqualTo("^/user/session$");
+    }
+
+    @Test
+    public void clients() throws Exception {
+        Pac4jFactory conf = getPac4jFactory("clients.yaml");
+        Config config = conf.build();
+
+        assertThat(config.getClients().getClients()).hasSize(2);
+
+        Client client = config.getClients().getClients().get(0);
+        assertThat(client).isInstanceOf(DirectBasicAuthClient.class);
+        assertThat(client.getName()).isEqualTo("DirectBasicAuthClient");
+        assertThat(((DirectBasicAuthClient) client).getAuthenticator())
+                .isNotNull()
+                .isInstanceOf(SimpleTestUsernamePasswordAuthenticator.class);
+
+        Client client1 = config.getClients().getClients().get(1);
+        assertThat(client1).isInstanceOf(DirectBasicAuthClient.class);
+        assertThat(client1.getName()).isEqualTo("basic");
+        assertThat(((DirectBasicAuthClient) client1).getAuthenticator())
+                .isNull();
+    }
+
+}

--- a/src/test/java/org/pac4j/dropwizard/e2e/DogsResource.java
+++ b/src/test/java/org/pac4j/dropwizard/e2e/DogsResource.java
@@ -1,4 +1,4 @@
-package org.pac4j.dropwizard;
+package org.pac4j.dropwizard.e2e;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;

--- a/src/test/java/org/pac4j/dropwizard/e2e/EndToEndTest.java
+++ b/src/test/java/org/pac4j/dropwizard/e2e/EndToEndTest.java
@@ -1,4 +1,4 @@
-package org.pac4j.dropwizard;
+package org.pac4j.dropwizard.e2e;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -21,14 +21,13 @@ import io.dropwizard.testing.DropwizardTestSupport;
 import io.dropwizard.testing.ResourceHelpers;
 
 public class EndToEndTest {
-    private DropwizardTestSupport dropwizardTestSupport;
+    private DropwizardTestSupport<TestConfiguration> dropwizardTestSupport;
     private Client client = new JerseyClientBuilder().build();
 
     public void setup(
             Class<? extends Application<TestConfiguration>> applicationClass,
             ConfigOverride... configOverrides) {
-        dropwizardTestSupport = new DropwizardTestSupport<TestConfiguration>(
-                applicationClass,
+        dropwizardTestSupport = new DropwizardTestSupport<>(applicationClass,
                 ResourceHelpers.resourceFilePath("end-to-end-test.yaml"),
                 configOverrides);
         dropwizardTestSupport.before();

--- a/src/test/java/org/pac4j/dropwizard/e2e/TestApplication.java
+++ b/src/test/java/org/pac4j/dropwizard/e2e/TestApplication.java
@@ -1,15 +1,14 @@
-package org.pac4j.dropwizard;
+package org.pac4j.dropwizard.e2e;
 
-import org.pac4j.core.client.Clients;
-import org.pac4j.core.config.ConfigSingleton;
-import org.pac4j.http.client.direct.DirectBasicAuthClient;
-import org.pac4j.http.credentials.authenticator.test.SimpleTestUsernamePasswordAuthenticator;
+import org.pac4j.dropwizard.Pac4jBundle;
+import org.pac4j.dropwizard.Pac4jFactory;
 
 import io.dropwizard.Application;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 
 public class TestApplication extends Application<TestConfiguration> {
+    
     @Override
     public void initialize(Bootstrap<TestConfiguration> bootstrap) {
         final Pac4jBundle<TestConfiguration> bundle = new Pac4jBundle<TestConfiguration>() {
@@ -21,13 +20,10 @@ public class TestApplication extends Application<TestConfiguration> {
         };
         bootstrap.addBundle(bundle);
     }
-
+    
     @Override
     public void run(TestConfiguration config, Environment env)
             throws Exception {
-        ConfigSingleton.getConfig()
-                .setClients(new Clients(new DirectBasicAuthClient(
-                        new SimpleTestUsernamePasswordAuthenticator())));
         env.jersey().register(new DogsResource());
     }
 }

--- a/src/test/java/org/pac4j/dropwizard/e2e/TestConfiguration.java
+++ b/src/test/java/org/pac4j/dropwizard/e2e/TestConfiguration.java
@@ -1,4 +1,6 @@
-package org.pac4j.dropwizard;
+package org.pac4j.dropwizard.e2e;
+
+import org.pac4j.dropwizard.Pac4jFactory;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/test/resources/clients.yaml
+++ b/src/test/resources/clients.yaml
@@ -1,0 +1,6 @@
+clients:
+  - org.pac4j.http.client.direct.DirectBasicAuthClient:
+      authenticator:
+        class: org.pac4j.http.credentials.authenticator.test.SimpleTestUsernamePasswordAuthenticator
+  - org.pac4j.http.client.direct.DirectBasicAuthClient:
+      name: basic

--- a/src/test/resources/end-to-end-test.yaml
+++ b/src/test/resources/end-to-end-test.yaml
@@ -5,9 +5,11 @@ server:
   adminConnectors:
     - type: http
       port: 0
+
 pac4j:
+  clients:
+    - org.pac4j.http.client.direct.DirectBasicAuthClient:
+        authenticator:
+          class: org.pac4j.http.credentials.authenticator.test.SimpleTestUsernamePasswordAuthenticator
   filters:
     - clients: ""
-      authorizers: ""
-      matchers: ""
-      multiProfile: false

--- a/src/test/resources/matchers.yaml
+++ b/src/test/resources/matchers.yaml
@@ -1,0 +1,4 @@
+matchers:
+  excludeUserSession:
+    class: org.pac4j.core.matching.ExcludedPathMatcher
+    excludePath: ^/user/session$


### PR DESCRIPTION
Now it is possible to specify global security filters (with `filters`), matchers, authorizers and the clients in the application's configuration.
For the clients, it is possible to specify the authenticator, and stuffs like that.

The pac4j configuration is now directly in the DW configuration, so no more need for `ConfigSingleton` to access it later.

Now, I need some feedbacks from you @evnm and @leleuj :)

@evnm I had to do a lot of tweaking with Jackson (using Mixins), is that the correct way to do it? Basically I wanted to be able to instantiate classes dynamically based on their name in the configuration.
There is some case where I would have preferred something better but I couldn't do it, for example, in the example, we have:
```yaml
pac4j:
  clients:
    clients:
      DirectBasicAuthClient:
        class: org.pac4j.http.client.direct.DirectBasicAuthClient
```
But it would have been nicer to be able ALSO to express it like this (if there is no other properties to set on the client):
```yaml
pac4j:
  clients:
    clients:
      DirectBasicAuthClient: org.pac4j.http.client.direct.DirectBasicAuthClient
```
The same with the other type of instantiable objects.

Also @evnm, I wanted to test only the configuration parsing, but I didn't find a way to do it without loading the whole application, not sure if it is possible? :)
And more generally, do you see something problematic?

@leleuj Did I forget some types that could be instantiated from the configuration? The list is in `Pac4jBundle` with the jackson Mixins as well as in the README :)
Do you see other things?

Thanks :)