### PR TITLE
Using class instead of object for registering ServletJaxRsContextFactoryProvider

### DIFF
--- a/src/main/java/org/pac4j/dropwizard/Pac4jBundle.java
+++ b/src/main/java/org/pac4j/dropwizard/Pac4jBundle.java
@@ -93,7 +93,7 @@ public abstract class Pac4jBundle<T extends Configuration>
             }
 
             environment.jersey()
-                    .register(new ServletJaxRsContextFactoryProvider());
+                    .register(ServletJaxRsContextFactoryProvider.class);
             environment.jersey().register(new Pac4JSecurityFeature());
             environment.jersey()
                     .register(new Pac4JValueFactoryProvider.Binder());

--- a/src/test/java/org/pac4j/dropwizard/bundle/BundleFactoryTest.java
+++ b/src/test/java/org/pac4j/dropwizard/bundle/BundleFactoryTest.java
@@ -22,9 +22,11 @@ public class BundleFactoryTest extends AbstractApplicationTest {
 
     }
 
-    private static final Condition<Object> CONDSI = new Condition<>(
-            s -> s instanceof ServletJaxRsContextFactoryProvider,
-            "pac4j singleton");
+    private static final Condition<Object> CONDCLASS = new Condition<>(
+            s -> {
+            		return s.equals(ServletJaxRsContextFactoryProvider.class);
+            	},
+            "pac4j class");
 
     @Test
     public void noPac4jInConfig() {
@@ -39,7 +41,7 @@ public class BundleFactoryTest extends AbstractApplicationTest {
         // registered anyway
         assertThat(om.findMixInClassFor(Client.class)).isNotNull();
         assertThat(env.jersey().getResourceConfig().getSingletons())
-                .doesNotHave(CONDSI);
+                .doesNotHave(CONDCLASS);
     }
 
     @Test
@@ -56,8 +58,8 @@ public class BundleFactoryTest extends AbstractApplicationTest {
         assertThat(config.getClients().getUrlResolver())
                 .isInstanceOf(JaxRsUrlResolver.class);
         assertThat(om.findMixInClassFor(Client.class)).isNotNull();
-        assertThat(env.jersey().getResourceConfig().getSingletons())
-                .haveAtLeastOne(CONDSI);
+        assertThat(env.jersey().getResourceConfig().getClasses())
+                .haveAtLeastOne(CONDCLASS);
 
         assertThat(env.getApplicationContext().getSessionHandler())
                 .isInstanceOf(SessionHandler.class);


### PR DESCRIPTION
The ServletJaxRsContextFactoryProvider uses a request scoped injection. 
<code>
    @Context
    private HttpServletRequest request;
</code>

While using dropwizard with guice, this class is registered in jersey environment as an object at the startup time. When guice tries to inject the HTTPServeltContext (as this is an instance created from default constructor), it doesn't find a request context (as this is still the startup time and request is made) and errors out.

<code>
// Pac4jBundle.run()
            environment.jersey()
                    .register(new ServletJaxRsContextFactoryProvider());
</code>

By passing on the class instead of the object, guice injection happens lazily on the first request to the application.