### PR TITLE
Backport v6.0.0 to support DropWizard 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ using [pac4j](http://www.pac4j.org/).
 | dropwizard-pac4j | JDK | pac4j | jax-rs-pac4j | Dropwizard |
 |------------------|-----|-------|--------------|------------|
 | version >= 6     | 11  | v5    | v6           | v4         |
+| version >= 5.3   | 11  | v5    | v5           | v3         |
 | version >= 5     | 11  | v4    | v4           | v2         |
 | version >= 4     | 8   | v4    | v4           | v1         |
 | version >= 3     | 8   | v3    | v3           | v1         |

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <groupId>org.pac4j</groupId>
   <artifactId>dropwizard-pac4j</artifactId>
   <packaging>jar</packaging>
-  <version>6.0.1-SNAPSHOT</version>
+  <version>5.3.0-SNAPSHOT</version>
   <name>Dropwizard pac4j Support</name>
   <description>Dropwizard bundle adding support for the pac4j security engine</description>
   <url>https://github.com/pac4j/dropwizard-pac4j</url>
@@ -90,9 +90,9 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <dropwizard.version>4.0.1</dropwizard.version>
+    <dropwizard.version>3.0.1</dropwizard.version>
     <pac4j.version>5.7.1</pac4j.version>
-    <jax-rs-pac4j.version>6.0.0</jax-rs-pac4j.version>
+    <jax-rs-pac4j.version>5.0.0</jax-rs-pac4j.version>
     <jee-pac4j.version>7.1.0</jee-pac4j.version>
     <junit5.version>5.10.0</junit5.version>
   </properties>
@@ -154,7 +154,7 @@
     </dependency>
     <dependency>
       <groupId>org.pac4j</groupId>
-      <artifactId>jersey3-pac4j</artifactId>
+      <artifactId>jersey2-pac4j</artifactId>
       <version>${jax-rs-pac4j.version}</version>
       <exclusions>
         <exclusion>
@@ -165,7 +165,7 @@
     </dependency>
     <dependency>
       <groupId>org.pac4j</groupId>
-      <artifactId>jakartaee-pac4j</artifactId>
+      <artifactId>javaee-pac4j</artifactId>
       <version>${jee-pac4j.version}</version>
       <exclusions>
         <exclusion>

--- a/src/main/java/org/pac4j/dropwizard/J2EHelper.java
+++ b/src/main/java/org/pac4j/dropwizard/J2EHelper.java
@@ -2,8 +2,8 @@ package org.pac4j.dropwizard;
 
 import java.util.EnumSet;
 
-import jakarta.servlet.DispatcherType;
-import jakarta.servlet.FilterRegistration;
+import javax.servlet.DispatcherType;
+import javax.servlet.FilterRegistration;
 
 import org.pac4j.core.config.Config;
 import org.pac4j.dropwizard.Pac4jFactory.ServletCallbackFilterConfiguration;

--- a/src/main/java/org/pac4j/dropwizard/Pac4jBundle.java
+++ b/src/main/java/org/pac4j/dropwizard/Pac4jBundle.java
@@ -77,7 +77,8 @@ public abstract class Pac4jBundle<T extends Configuration>
                 environment.jersey()
                         .register(new Pac4JSecurityFilterFeature(
                                 fConf.getSkipResponse(), fConf.getAuthorizers(),
-                                fConf.getClients(), fConf.getMatchers()));
+                                fConf.getClients(), fConf.getMatchers(),
+                                fConf.getMultiProfile()));
             }
 
             for (ServletSecurityFilterConfiguration fConf : pac4j.getServlet()

--- a/src/main/java/org/pac4j/dropwizard/Pac4jFactory.java
+++ b/src/main/java/org/pac4j/dropwizard/Pac4jFactory.java
@@ -5,7 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.validation.constraints.NotNull;
+import javax.validation.constraints.NotNull;
 
 import org.pac4j.config.client.PropertiesConfigFactory;
 import org.pac4j.core.authorization.authorizer.Authorizer;
@@ -496,6 +496,8 @@ public class Pac4jFactory {
 
         private String matchers;
 
+        private Boolean multiProfile;
+
         @JsonProperty
         public String getClients() {
             return clients;
@@ -512,9 +514,15 @@ public class Pac4jFactory {
         }
 
         @JsonProperty
+        public Boolean getMultiProfile() {
+            return multiProfile;
+        }
+
+        @JsonProperty
         public void setClients(String clients) {
             this.clients = clients;
         }
+
 
         @JsonProperty
         public void setAuthorizers(String authorizers) {
@@ -525,6 +533,12 @@ public class Pac4jFactory {
         public void setMatchers(String matchers) {
             this.matchers = matchers;
         }
+
+        @JsonProperty
+        public void setMultiProfile(Boolean multiProfile) {
+            this.multiProfile = multiProfile;
+        }
+
     }
 
     /**

--- a/src/test/java/org/pac4j/dropwizard/AbstractApplicationTest.java
+++ b/src/test/java/org/pac4j/dropwizard/AbstractApplicationTest.java
@@ -1,6 +1,6 @@
 package org.pac4j.dropwizard;
 
-import jakarta.ws.rs.client.Client;
+import javax.ws.rs.client.Client;
 
 import org.glassfish.jersey.client.JerseyClientBuilder;
 import org.junit.jupiter.api.AfterEach;

--- a/src/test/java/org/pac4j/dropwizard/e2e/DogsResource.java
+++ b/src/test/java/org/pac4j/dropwizard/e2e/DogsResource.java
@@ -2,12 +2,12 @@ package org.pac4j.dropwizard.e2e;
 
 import java.util.Optional;
 
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.MediaType;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 
 @Path("/dogs")
 @Produces(MediaType.APPLICATION_JSON)

--- a/src/test/java/org/pac4j/dropwizard/e2e/EndToEndServletTest.java
+++ b/src/test/java/org/pac4j/dropwizard/e2e/EndToEndServletTest.java
@@ -2,11 +2,11 @@ package org.pac4j.dropwizard.e2e;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.Form;
-import jakarta.ws.rs.core.HttpHeaders;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 import org.junit.jupiter.api.Test;
 import org.pac4j.dropwizard.AbstractApplicationTest;

--- a/src/test/java/org/pac4j/dropwizard/e2e/EndToEndTest.java
+++ b/src/test/java/org/pac4j/dropwizard/e2e/EndToEndTest.java
@@ -2,11 +2,11 @@ package org.pac4j.dropwizard.e2e;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.Form;
-import jakarta.ws.rs.core.HttpHeaders;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 import org.junit.jupiter.api.Test;
 import org.pac4j.dropwizard.AbstractApplicationTest;


### PR DESCRIPTION
Here's a first pass at DropWizard 3 support. I started with the 6.0.0 version (actually the current tip of the master branch) and then modified it to work with DropWizard3. I've been running with essentially this code in my production app for a while and it seems to work fine.

I'm proposing naming the new version 5.3.0. That is a little awkward as it really ought to be a new major version number, but making it version 7 feels too weird as it would be supporting an older version of DropWizard than version 6. I'm not sure what the best path forward is here or if this would be an acceptable solution, 5.3.0 felt like the best option.

This is PR'd against the master branch, but I don't think it should land there. Ideally it would be PR'd to a v5.3 branch created from the master branch, but I don't believe I can do that in the PR.

As far as I can tell, this PR is fully functional, passes all the tests, and matches the existing coding style. I'm happy to make whatever changes are needed, but I'm also fine with someone else making the changes themselves.